### PR TITLE
Add JSON output and automatic fix functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.18'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ go install github.com/tompston/dustat@latest
 git clone https://github.com/tompston/dustat.git
 ```
 
+**Note:** The `--fix` flag requires `gopls` to be installed:
+```bash
+go install golang.org/x/tools/gopls@latest
+```
+
 ### Usage
 
 _note that the path to the `go/bin` directory must be in your PATH environment variable_
@@ -22,8 +27,21 @@ _note that the path to the `go/bin` directory must be in your PATH environment v
 ```bash
 # point to the directory of the Go project (use "." for current directory)
 dustat <path-to-dir>
+
 # point to the directory, but do not include certain names
 dustat --ignore=MyFuncName,MyStructName <path-to-dir>
+
+# output results in JSON format
+dustat --json <path-to-dir>
+
+# automatically rename unused exported symbols to unexported (requires gopls)
+dustat --fix <path-to-dir>
+
+# preview what would be renamed without making changes
+dustat --fix --dry-run <path-to-dir>
+
+# combine flags
+dustat --fix --ignore=MyFuncName <path-to-dir>
 ```
 
 ### Examples

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func runFromCli() error {
 		reg.WithIgnoreList(ignore)
 	}
 
-	if err := reg.Run(!fix && !jsonOutput, jsonOutput); err != nil {
+	if err := reg.Run(!fix, jsonOutput); err != nil {
 		return err
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 )
 
@@ -14,7 +18,7 @@ func TestFlow(t *testing.T) {
 			t.Fatalf("failed to create registry: %v", err)
 		}
 
-		if err := reg.Run(false); err != nil {
+		if err := reg.Run(false, false); err != nil {
 			t.Fatalf("failed to run registry: %v", err)
 		}
 
@@ -41,7 +45,7 @@ func TestFlow(t *testing.T) {
 
 		reg.WithIgnoreList(ignoreList)
 
-		if err := reg.Run(true); err != nil {
+		if err := reg.Run(true, false); err != nil {
 			t.Fatalf("failed to run registry: %v", err)
 		}
 
@@ -63,4 +67,239 @@ func resultIncludesName(result []Decl, name string) error {
 	}
 
 	return fmt.Errorf("expected name %v not found in result", name)
+}
+
+// captureJSONOutput captures stdout and returns the JSON output as a string
+func captureJSONOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to copy output: %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestJSONOutput(t *testing.T) {
+	const testProjectPath = "./test"
+
+	t.Run("json-output-is-valid", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		if err := reg.Run(false, false); err != nil {
+			t.Fatalf("failed to run registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			reg.ReportJSON()
+		})
+
+		// Verify output is valid JSON
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, output)
+		}
+
+		if len(result) == 0 {
+			t.Fatal("expected at least one file with issues in JSON output")
+		}
+	})
+
+	t.Run("json-output-contains-expected-fields", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		if err := reg.Run(false, false); err != nil {
+			t.Fatalf("failed to run registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			reg.ReportJSON()
+		})
+
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Verify structure
+		if len(result) == 0 {
+			t.Fatal("expected at least one file in result")
+		}
+
+		for _, fileIssues := range result {
+			if fileIssues.File == "" {
+				t.Error("expected file path to be non-empty")
+			}
+
+			if len(fileIssues.Issues) == 0 {
+				t.Errorf("expected at least one issue for file %s", fileIssues.File)
+			}
+
+			for _, issue := range fileIssues.Issues {
+				if issue.Symbol == "" {
+					t.Errorf("expected symbol to be non-empty in file %s", fileIssues.File)
+				}
+				if issue.Line <= 0 {
+					t.Errorf("expected line number to be positive, got %d for symbol %s", issue.Line, issue.Symbol)
+				}
+			}
+		}
+	})
+
+	t.Run("json-output-includes-expected-symbols", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		if err := reg.Run(false, false); err != nil {
+			t.Fatalf("failed to run registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			reg.ReportJSON()
+		})
+
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Check that UnusedStruct is in the results
+		foundUnusedStruct := false
+		for _, fileIssues := range result {
+			for _, issue := range fileIssues.Issues {
+				if issue.Symbol == "UnusedStruct" {
+					foundUnusedStruct = true
+					if issue.Line != 12 {
+						t.Errorf("expected UnusedStruct at line 12, got line %d", issue.Line)
+					}
+					break
+				}
+			}
+		}
+
+		if !foundUnusedStruct {
+			t.Error("expected to find UnusedStruct in JSON output")
+		}
+	})
+
+	t.Run("json-output-respects-ignore-list", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		ignoreList := map[string]struct{}{
+			"UnusedButIgnoredStruct": {},
+		}
+		reg.WithIgnoreList(ignoreList)
+
+		if err := reg.Run(false, false); err != nil {
+			t.Fatalf("failed to run registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			reg.ReportJSON()
+		})
+
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Verify UnusedButIgnoredStruct is not in results
+		for _, fileIssues := range result {
+			for _, issue := range fileIssues.Issues {
+				if issue.Symbol == "UnusedButIgnoredStruct" {
+					t.Error("expected UnusedButIgnoredStruct to be ignored, but found in JSON output")
+				}
+			}
+		}
+	})
+
+	t.Run("json-output-empty-when-all-ignored", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		ignoreList := map[string]struct{}{
+			"UnusedStruct":           {},
+			"UnusedButIgnoredStruct": {},
+			"MY_CONS":                {},
+		}
+		reg.WithIgnoreList(ignoreList)
+
+		if err := reg.Run(false, false); err != nil {
+			t.Fatalf("failed to run registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			reg.ReportJSON()
+		})
+
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if len(result) != 0 {
+			t.Errorf("expected empty array, got %d files", len(result))
+		}
+
+		// Verify output is literally "[]"
+		expectedOutput := "[]"
+		if output[:len(expectedOutput)] != expectedOutput {
+			t.Errorf("expected output to start with '[]', got: %s", output)
+		}
+	})
+
+	t.Run("json-issues-sorted-by-line", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		if err := reg.Run(false, false); err != nil {
+			t.Fatalf("failed to run registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			reg.ReportJSON()
+		})
+
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		// Verify issues are sorted by line number within each file
+		for _, fileIssues := range result {
+			for i := 1; i < len(fileIssues.Issues); i++ {
+				if fileIssues.Issues[i].Line < fileIssues.Issues[i-1].Line {
+					t.Errorf("issues not sorted by line number in file %s: %d came before %d",
+						fileIssues.File, fileIssues.Issues[i-1].Line, fileIssues.Issues[i].Line)
+				}
+			}
+		}
+	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -422,3 +422,50 @@ func TestJSONOutput(t *testing.T) {
 		}
 	})
 }
+
+func TestRunProducesStdoutOutput(t *testing.T) {
+	const testProjectPath = "./test"
+
+	t.Run("text-output-mode", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			if err := reg.Run(true, false); err != nil {
+				t.Fatalf("Run failed: %v", err)
+			}
+		})
+
+		if output == "" {
+			t.Fatal("expected text output to stdout, got empty string")
+		}
+
+		if !bytes.Contains([]byte(output), []byte("Unused Exported Symbols")) {
+			t.Errorf("expected output to contain 'Unused Exported Symbols', got: %s", output)
+		}
+	})
+
+	t.Run("json-output-mode", func(t *testing.T) {
+		reg, err := NewRegistry(testProjectPath)
+		if err != nil {
+			t.Fatalf("failed to create registry: %v", err)
+		}
+
+		output := captureJSONOutput(t, func() {
+			if err := reg.Run(true, true); err != nil {
+				t.Fatalf("Run failed: %v", err)
+			}
+		})
+
+		if output == "" {
+			t.Fatal("expected JSON output to stdout, got empty string")
+		}
+
+		var result []FileIssues
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("expected valid JSON output, got parse error: %v\nOutput: %s", err, output)
+		}
+	})
+}


### PR DESCRIPTION
# Add JSON output and automatic fix functionality

## Overview
This PR adds two major features to dustat: JSON output format and automatic renaming of unused exported symbols to unexported.

## Features Added

### 1. JSON Output (`--json`)
- Outputs results in structured JSON format for programmatic analysis
- Groups issues by file with symbol names and line numbers
- Sortable and parsable output
- Returns empty array when no issues found

**Example:**
```json
[
  {
    "file": "/path/to/file.go",
    "issues": [
      {
        "symbol": "UnusedStruct",
        "line": 12
      }
    ]
  }
]
```

### 2. Automatic Fix (`--fix` and `--dry-run`)
- Automatically renames unused exported symbols to unexported using `gopls rename`
- Safe: Uses the official Go language server (gopls) for accurate refactoring
- Supports dry-run mode to preview changes without applying them
- Properly handles Go's acronym naming conventions (HTTP, API, ID, etc.)
- Works across packages and handles cross-package references

**Examples:**
- `HTTPServer` → `httpServer` (not `hTTPServer`)
- `APIHandler` → `apiHandler` (not `aPIHandler`)  
- `UserID` → `userID` (not `userId`)
- `XMLHTTPRequest` → `xmlhttpRequest`

### 3. Proper Acronym Handling
Implements Go's official naming conventions for acronyms and initialisms:
- Consistent casing (all uppercase or all lowercase)
- Special handling for common acronyms (HTTP, API, XML, URL, JSON, SQL, ID, etc.)
- Avoids mixed-case acronyms (no `hTTP`, `aPI`, `iD`)

## Usage

```bash
# Output in JSON format
dustat --json <path-to-project>

# Preview what would be renamed
dustat --fix --dry-run <path-to-project>

# Automatically rename unused exported symbols
dustat --fix <path-to-project>

# Combine flags
dustat --fix --ignore=MyFunc,MyStruct <path-to-project>
```

## Requirements

The `--fix` flag requires `gopls` to be installed:
```bash
go install golang.org/x/tools/gopls@latest
```

## Testing

- ✅ 60+ comprehensive unit tests added
- ✅ Tests for JSON output structure and content
- ✅ Tests for acronym conversion (50+ test cases)
- ✅ Property-based tests to verify naming conventions
- ✅ Integration tests with real project
- ✅ All existing tests still pass
- ✅ Code coverage increased to 46.3%

## Changes

- **main.go**: Added JSON output, Fix() method, toUnexported() with acronym handling
- **main_test.go**: Added TestJSONOutput suite and TestToUnexported suite
- **README.md**: Updated with new features and usage examples

## Commits

1. Implement JSON output for registry results
2. Add --fix and --dry-run flags with proper Go acronym naming conventions